### PR TITLE
Fix metadata typo

### DIFF
--- a/ocx-ticketing/src/app/layout.tsx
+++ b/ocx-ticketing/src/app/layout.tsx
@@ -14,7 +14,7 @@ const geistMono = Geist_Mono({
 
 export const metadata: Metadata = {
   title: "ỚT CAY XÈ 4",
-  description: "Builed by Howls Studio",
+  description: "Built by Howls Studio",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
- fix typographical error in layout metadata

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font resources)*

------
https://chatgpt.com/codex/tasks/task_e_683fbe525bc88321ab34ba386a7918d0